### PR TITLE
feat: Add main menu and implement custom sorting for navigation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ This section tracks the development plan for the recruitment task. Tasks are mar
 
 - [x] Set up GitHub repository with `.gitignore` and basic Astro structure
 - [x] Install and configure TinaCMS with Astro
-- [ ] Define and configure link collection for footer
-- [ ] Add rich text footer content editable via CMS
+- [x] Define and configure link collection for footer
+- [x] Add rich text footer content editable via CMS
 - [ ] Build paginated section for TypeScript knowledge entries
 - [ ] Set up Playwright for E2E testing
 - [ ] Configure CI/CD with GitHub Actions and Cloudflare Pages

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,9 +1,21 @@
 ---
 import { getCollection, getEntry } from 'astro:content';
 
-const internalLinks = await getCollection('internal-links');
-const externalLinks = await getCollection('external-links');
-const allLinks = [...internalLinks, ...externalLinks];
+const priorityInternalLinks = ["home", "types", "advantages"]
+const internalLinks = (await getCollection('internal-links')).sort((a, b) => {
+  const aIndex = priorityInternalLinks.indexOf(a.id);
+  const bIndex = priorityInternalLinks.indexOf(b.id);
+  if (aIndex === -1 && bIndex === -1) return 0;
+  if (aIndex === -1) return 1;
+  if (bIndex === -1) return -1;
+  return aIndex - bIndex;
+});
+
+const externalLinks = (await getCollection('external-links')).sort((a, b) => {
+  if (a.id === 'typeScriptHandbook') return -1;
+  if (b.id === 'typeScriptHandbook') return 1;
+  return 0;
+});
 const footer = await getEntry('globals', 'footer');
 ---
 

--- a/src/components/MainMenu.astro
+++ b/src/components/MainMenu.astro
@@ -1,0 +1,23 @@
+---
+import { getCollection } from 'astro:content';
+
+const priorityInternalLinks = ["home", "types", "advantages"]
+const internalLinks = (await getCollection('internal-links')).sort((a, b) => {
+  const aIndex = priorityInternalLinks.indexOf(a.id);
+  const bIndex = priorityInternalLinks.indexOf(b.id);
+  if (aIndex === -1 && bIndex === -1) return 0;
+  if (aIndex === -1) return 1;
+  if (bIndex === -1) return -1;
+  return aIndex - bIndex;
+});
+---
+
+<nav class="navbar navbar-expand-lg navbar-light bg-light d-flex justify-content-end align-items-center">
+    <ul class="navbar-nav">
+        {internalLinks.map(({ data }) => (
+            <li class="nav-item">
+                <a class="nav-link" href={data.url}>{data.label}</a>
+            </li>
+        ))}
+    </ul>
+</nav>

--- a/src/content/external-links/githubRepository.json
+++ b/src/content/external-links/githubRepository.json
@@ -1,7 +1,7 @@
 {
     "label": "GitHub Repository",
     "url": "https://github.com/microsoft/TypeScript",
-    "icon": "🐙",
+    "icon": "🚀",
     "description": "Contribute or follow development progress.",
     "external": true
   }

--- a/src/content/external-links/playground.json
+++ b/src/content/external-links/playground.json
@@ -1,7 +1,7 @@
 {
     "label": "Playground",
     "url": "https://www.typescriptlang.org/play",
-    "icon": "🧪",
+    "icon": "🐙",
     "description": "Try TypeScript directly in your browser.",
     "external": true
   }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import MainMenu from '../components/MainMenu.astro';
 import Footer from '../components/Footer.astro';
 ---
 
@@ -14,7 +15,9 @@ import Footer from '../components/Footer.astro';
 		<title>Typescript Compendium</title>
 	</head>
 	<body class="container">
-	<header class="my-4">Header part</header>
+	<header class="my-4">
+		<MainMenu />
+	</header>
 	<main>
 		<slot />
 	</main>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,7 +3,12 @@ import Layout from '../layouts/Layout.astro';
 import {getCollection, getEntry} from 'astro:content'
 
 //const all = await getCollection('main-page');
-const externalLinks = await getCollection('external-links');
+const externalLinks = (await getCollection('external-links')).sort((a, b) => {
+  // typeScriptHandbook na początek
+  if (a.id === 'typeScriptHandbook') return -1;
+  if (b.id === 'typeScriptHandbook') return 1;
+  return 0;
+});
 const welcome = await getEntry('main-page', 'welcome');
 
 let Content;
@@ -32,15 +37,14 @@ if (welcome) {
                         <Content/>
                         <section>
                             <h3>Official resources</h3>
-                            <ul>
+                            <ul class="list-unstyled">
                                 {externalLinks.map(({data}) => (
                                         <li>
 											<span>{data.icon}</span>
                                             <a href={data.url} target="_blank" rel="noopener noreferrer">
                                                 {data.label}
                                             </a>
-                                            {data.description &&
-                                                    <> — {data.description}</>}
+                                            {data.description && <> — {data.description}</>}
                                         </li>
                                 ))}
                             </ul>


### PR DESCRIPTION
This commit introduces the main navigation menu and adds a sorting mechanism for internal-links and external-links collections to ensure a consistent order. Create MainMenu.astro component: A new component has been created to display the primary site navigation. It fetches internal-links and sorts them according to a predefined priority list (home, types, advantages). Integrate MainMenu into Layout.astro: The MainMenu.astro component has been added to the main Layout.astro, making it visible across all pages. Implement Link Sorting: Custom sorting logic has been applied to the astro:content collections for both internal and external links. This ensures that links in the main menu, on the homepage, and in the footer are always displayed in a predictable and desired order.