### PR TITLE
Change the conditional execution of the 'Publish to Cloudflare Pages'…

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -39,7 +39,7 @@ jobs:
         path: tests/**/*.ts-snapshots/
         retention-days: 7
     - name: Publish to Cloudflare Pages
-      if: ${{ !cancelled() }}
+      if: always()
       uses: cloudflare/pages-action@v1
       id: publish_report
       with:


### PR DESCRIPTION
… step from 'if: !cancelled()' to 'if: always()'.

This ensures that the Playwright test report is deployed regardless of the test outcome (success or failure), making the reporting process more reliable.